### PR TITLE
Updated localhost config redirection & README.md for local compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,20 @@ The information presented here is based on my personal understanding and researc
 
 [![Go Learning](https://img.shields.io/badge/Go%20Learning-BLOG-blue?style=for-the-badge)](https://kitanob.github.io/OCP17-NotesAndResources/docs/)
 
+## **How to build & start project locally**
+
+There is required few steps before starting launching and editing real-time pages on this project.
+
+Because this Hugo site uses theme template to work with a given submodule, you need to retrieve it alongside the project :
+``git clone --recurse-submodules``
+
+You may also install Hugo to build and run the project locally. Have a look [here](https://gohugo.io/installation/).
+
+As described on Hugo's website, to launch locally the website, use this command : ``hugo server -D``
+
+Have fun !
+
+
+
 
 

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ summaryLength = 30
     weight = 1
 
 [params]
+  localURL = "http://localhost:1313/OCP17-NotesAndResources/"
   google_analytics_id=""
   homepage_button_link = 'https://kitanob.github.io/OCP17-NotesAndResources/docs/'
   homepage_button_text = 'Read The Docs'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,14 +16,20 @@
 {{ end }}
 
 {{ define "main" }}
+{{ $baseUrl := .Site.BaseURL }}
+
+{{ if eq hugo.Environment "development" }}
+  {{ $baseUrl := .Site.Params.localURL }}
+{{ end }}
+
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="refresh" content="0; url=https://kitanob.github.io/OCP17-NotesAndResources/docs/" />
-  <link rel="canonical" href="https://kitanob.github.io/OCP17-NotesAndResources/docs/" />
+  <meta http-equiv="refresh" content="0; url={{ $baseUrl }}/docs/" />
+  <link rel="canonical" href="{{ $baseUrl }}/docs/" />
 </head>
 <body>
-  <p>If you are not redirected, <a href="https://kitanob.github.io/OCP17-NotesAndResources/docs/">click here</a>.</p>
+  <p>If you are not redirected, <a href="{{ $baseUrl }}/docs/">click here</a>.</p>
 </body>
 </html>
 


### PR DESCRIPTION
- Added instructions in README.md for quick setup locally : for begineer of Hugo framework, it is hard to understand to quickly setup the project locally.
- Updated localhost redirection : when browser goes to index.html of the project, it automatically redirects to the GitHub-Pages' project, which is not preferrable in localhost environment. Instead, it will redirect to localhost documents.